### PR TITLE
Replace '/' in chapter name with something else

### DIFF
--- a/src/chapters.py
+++ b/src/chapters.py
@@ -9,6 +9,7 @@ from src.download import download
 SKIP_CHAPTER = "https://file.tokybook.com/upload/welcome-you-to-tokybook.mp3"
 MEDIA_URL = "https://files01.tokybook.com/audio/"
 MEDIA_FALLBACK_URL = "https://files02.tokybook.com/audio/"
+SLASH_REPLACE_STRING = " out of "
 
 def get_chapters(BOOK_URL):
     html = get(BOOK_URL)
@@ -45,7 +46,7 @@ def get_chapters(BOOK_URL):
         try:
             download(
                 MEDIA_URL + item["url"],
-                path.join(download_folder, item["name"] + ".mp3"),
+                path.join(download_folder, SLASH_REPLACE_STRING.join(item["name"].split("/")) + ".mp3"),
             )
             print()
 


### PR DESCRIPTION
`/` is used on most systems as a delimiter for directories. While downloading certain books from TokyBooks, sometimes the chapter numbers are included in the chapter file names in the format of `chapter/total` (e.g. `25/41`), which caused the files to be incorrectly placed in a subdirectory. This PR just replaces that `/` (if it exists) with another string, in this case using ` of `.