### PR TITLE
It appears to work fine in Python 3.13.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 > Snatch audiobooks from Tokybook 😈
 
-> [!CAUTION]
->
-> - Python 3.13 is not supported, yet.
->
-
 ## Installation
 
 1. Open terminal, then run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tokysnatcher"
 version = "0.3.1"
 description = "A simple audiobook downloader for tokybook.com"
 readme = "README.md"
-requires-python = ">=3.7,<=3.12.7"
+requires-python = ">=3.7,<3.14"
 dependencies = [
   "gazpacho==1.1",
   "halo==0.0.31",


### PR DESCRIPTION
What's the problem? Why is 3.13 "not supported yet"?