### PR TITLE
fix(ci): add virtual environment creation to workflow jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
 
+      - name: Create virtual environment
+        run: uv venv
+
       - name: Debug uv
         run: |
           uv --version || uv --help
@@ -132,6 +135,9 @@ jobs:
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
+
+      - name: Create virtual environment
+        run: uv venv
 
       - name: Debug uv
         run: |


### PR DESCRIPTION
Fix GitHub Actions failure due to missing virtual environment for uv commands in lint and publish jobs.

- Add 'uv venv' step after 'Setup uv' in both lint and publish jobs
- This resolves the error: No virtual environment found; run uv venv to create an environment